### PR TITLE
chore: pin tar to 4.4.19 to address hardlink/symlink extraction vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3202,7 +3202,7 @@
               "optional": true
             },
             "tar": {
-              "version": "4.4.8",
+              "version": "4.4.19",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -7275,7 +7275,7 @@
               "optional": true
             },
             "tar": {
-              "version": "4.4.8",
+              "version": "4.4.19",
               "bundled": true,
               "optional": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "tar": "4.4.19"
   }
 }


### PR DESCRIPTION
### Motivation
- Remediate an arbitrary file read/write via hardlink target escape in `node-tar` extraction by ensuring project resolves a patched `tar` version.

### Description
- Added an `overrides` entry in `package.json` to pin `tar` to `4.4.19`.
- Updated the two vulnerable `tar` entries in `package-lock.json` from `4.4.8` to `4.4.19` (bundled locations).
- Committed the change as `chore: patch tar dependency against hardlink escape vuln`.

### Testing
- Ran `npm install --package-lock-only` which completed and updated the lockfile successfully.
- Verified with `node -e` that `package-lock.json` no longer contains `"version": "4.4.8"` (check returned negative for `4.4.8`).
- Attempted `npm install` / `npm audit` and `npm view` but registry requests returned `403` in this environment so full dependency install and audit could not be completed. 
- Attempted `npm run build` which failed because `react-scripts` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997dc86c5648325a7191a364aa30417)